### PR TITLE
Add custom `core::fmt::Debug` impl

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "approx")]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 use core::cmp::Ordering;
-use core::fmt::{self, Display, Formatter, LowerExp, UpperExp};
+use core::fmt::{self, Debug, Display, Formatter, LowerExp, UpperExp};
 use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
 use core::marker::PhantomData;
@@ -46,7 +46,7 @@ use crate::{Encoding, Finite, Infinite, Nan, NotNan, Ordered, Primitive, Real};
 /// This type is re-exported but should not (and cannot) be used directly. Use
 /// the exported type aliases instead (`Ordered`, `NotNan`, and `Finite`).
 #[cfg_attr(feature = "serialize-serde", derive(Deserialize, Serialize))]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 #[repr(transparent)]
 pub struct ConstrainedFloat<T, P>
 where
@@ -370,6 +370,16 @@ where
 {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         self.as_ref().fmt(f)
+    }
+}
+
+impl<T, P> Debug for ConstrainedFloat<T, P>
+where
+    T: Debug + Float + Primitive,
+    P: FloatConstraint<T>,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "ConstrainedFloat({:?})", self.into_inner())
     }
 }
 
@@ -1706,10 +1716,10 @@ mod tests {
     #[test]
     fn fmt() {
         let x: Ordered<f32> = 1.0.into();
-        format_args!("{0} {0:e} {0:E} {0:?}", x);
+        format_args!("{0} {0:e} {0:E} {0:?} {0:#?}", x);
         let y: NotNan<f32> = 1.0.into();
-        format_args!("{0} {0:e} {0:E} {0:?}", y);
+        format_args!("{0} {0:e} {0:E} {0:?} {0:#?}", y);
         let z: Finite<f32> = 1.0.into();
-        format_args!("{0} {0:e} {0:E} {0:?}", z);
+        format_args!("{0} {0:e} {0:E} {0:?} {0:#?}", z);
     }
 }


### PR DESCRIPTION
This implements the changes discussed in #19. I originally hoped that we could have impls for `R32`, `N32` etc since these names would be both shorter and more precise, but this wouldn't allow for an additional blanket impl for non-aliased `ConstrainedFloat` types on stable rust, so I just went with the simple version that you proposed. Perhaps we can revisit that when specialization gets stabilized soon™.

The current implementation always prints on a single line. An alternative implementation could be to use

```rust
f.debug_tuple("ConstrainedFloat").field(&self.into_inner()).finish()
```

which would print on a single line when formatted with `{:?}` and on 3 lines when formatted via `{:#?}`.

Personally, I feel like the always-one-line impl is more appropriate, however I don't really have too much of a strong opinion on that, so if you want me to switch this, just let me know!