### PR TITLE
Serialize and deserialize ConstrainedFloats as floats

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -65,6 +65,7 @@ use crate::{ForeignReal, N32, N64, R32, R64};
 #[repr(transparent)]
 pub struct ConstrainedFloat<T, P> {
     value: T,
+    #[cfg_attr(feature = "serialize-serde", serde(skip))]
     phantom: PhantomData<P>,
 }
 


### PR DESCRIPTION
Currently Serde serializes ConstrainedFloats with a PhantomData field and fails to deserialize raw floats.  This change causes Serde to treat ConstrainedFloats as if they were a normal float which is being constructed.

I'm not sure if the `#[serde(transparent)]` is needed with `#[repr(transparent)]`, but I included it just in case.