### PR TITLE
Add implementations for std::ops traits that work on references

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -533,6 +533,36 @@ op_ref!(Mul, mul);
 op_ref!(Div, div);
 op_ref!(Rem, rem);
 
+macro_rules! op_assign_ref {
+    ($trait_name: ident, $fn_name: ident) => {
+        impl<T, P> $trait_name<&ConstrainedFloat<T, P>> for ConstrainedFloat<T, P>
+        where
+            T: Float + Primitive,
+            P: Constraint<T>,
+        {
+            fn $fn_name(&mut self, other: &ConstrainedFloat<T, P>) {
+                $trait_name::$fn_name(self, *other)
+            }
+        }
+
+        impl<T, P> $trait_name<&T> for ConstrainedFloat<T, P>
+        where
+            T: Float + Primitive,
+            P: Constraint<T>,
+        {
+            fn $fn_name(&mut self, other: &T) {
+                $trait_name::$fn_name(self, *other)
+            }
+        }
+    };
+}
+
+op_assign_ref!(AddAssign, add_assign);
+op_assign_ref!(SubAssign, sub_assign);
+op_assign_ref!(MulAssign, mul_assign);
+op_assign_ref!(DivAssign, div_assign);
+op_assign_ref!(RemAssign, rem_assign);
+
 impl<T, P> Encoding for ConstrainedFloat<T, P>
 where
     T: Float + Primitive,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1113,6 +1113,18 @@ where
     }
 }
 
+impl<T, P> Neg for &ConstrainedFloat<T, P>
+where
+    T: Float + Primitive,
+    P: Constraint<T>,
+{
+    type Output = ConstrainedFloat<T, P>;
+
+    fn neg(self) -> Self::Output {
+        ConstrainedFloat::from_inner_unchecked(-self.into_inner())
+    }
+}
+
 impl<T, P> Num for ConstrainedFloat<T, P>
 where
     Self: PartialEq,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -451,6 +451,88 @@ where
     }
 }
 
+macro_rules! op_ref {
+    ($trait_name: ident, $fn_name: ident) => {
+        impl<T, P> $trait_name for &ConstrainedFloat<T, P>
+        where
+            T: Float + Primitive,
+            P: Constraint<T>,
+        {
+            type Output = ConstrainedFloat<T, P>;
+
+            fn $fn_name(self, other: Self) -> Self::Output {
+                $trait_name::$fn_name(*self, *other)
+            }
+        }
+
+        impl<T, P> $trait_name<ConstrainedFloat<T, P>> for &ConstrainedFloat<T, P>
+        where
+            T: Float + Primitive,
+            P: Constraint<T>,
+        {
+            type Output = ConstrainedFloat<T, P>;
+
+            fn $fn_name(self, other: ConstrainedFloat<T, P>) -> Self::Output {
+                $trait_name::$fn_name(*self, other)
+            }
+        }
+
+        impl<T, P> $trait_name<&ConstrainedFloat<T, P>> for ConstrainedFloat<T, P>
+        where
+            T: Float + Primitive,
+            P: Constraint<T>,
+        {
+            type Output = ConstrainedFloat<T, P>;
+
+            fn $fn_name(self, other: &ConstrainedFloat<T, P>) -> Self::Output {
+                $trait_name::$fn_name(self, *other)
+            }
+        }
+
+        impl<T, P> $trait_name<&T> for &ConstrainedFloat<T, P>
+        where
+            T: Float + Primitive,
+            P: Constraint<T>,
+        {
+            type Output = ConstrainedFloat<T, P>;
+
+            fn $fn_name(self, other: &T) -> Self::Output {
+                $trait_name::$fn_name(*self, *other)
+            }
+        }
+
+        impl<T, P> $trait_name<T> for &ConstrainedFloat<T, P>
+        where
+            T: Float + Primitive,
+            P: Constraint<T>,
+        {
+            type Output = ConstrainedFloat<T, P>;
+
+            fn $fn_name(self, other: T) -> Self::Output {
+                $trait_name::$fn_name(*self, other)
+            }
+        }
+
+        impl<T, P> $trait_name<&T> for ConstrainedFloat<T, P>
+        where
+            T: Float + Primitive,
+            P: Constraint<T>,
+        {
+            type Output = ConstrainedFloat<T, P>;
+
+            fn $fn_name(self, other: &T) -> Self::Output {
+                $trait_name::$fn_name(self, *other)
+            }
+        }
+    };
+}
+
+op_ref!(Add, add);
+op_ref!(Sub, sub);
+op_ref!(Mul, mul);
+op_ref!(Div, div);
+op_ref!(Rem, rem);
+
 impl<T, P> Encoding for ConstrainedFloat<T, P>
 where
     T: Float + Primitive,


### PR DESCRIPTION
For the Add trait, std has:

 - `impl Add<f64> for f64`
 - `impl<'a> Add<f64> for &'a f64`
 - `impl<'_> Add<&'_ f64> for f64`
 - `impl<'_, '_> Add<&'_ f64> for &'_ f64`

This PR adds the last three for ConstrainedFloat, for Add, Mul, Sub,
Div, Rem.

It also add similar implementations for {Add,Mul,Sub,Div,Rem}Assign and Neg. 