### PR TITLE
publicly export `constraint::Constraint` but seal it

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -17,13 +17,15 @@ pub trait SubsetOf<P> {}
 
 impl<P, Q> SubsetOf<Q> for P where Q: SupersetOf<P> {}
 
+pub trait Sealed {}
+
 /// Describes constraints on the set of floating-point values that a proxy type
 /// may represent.
 ///
 /// This trait expresses a constraint by filter-mapping values. Note that
 /// constraints require `Member<RealSet>`, meaning that the set of real numbers
 /// must always be supported and is implied.
-pub trait Constraint<T>: Copy + Member<RealSet> + Sized
+pub trait Constraint<T>: Copy + Member<RealSet> + Sized + Sealed
 where
     T: Float + Primitive,
 {
@@ -58,6 +60,8 @@ where
     }
 }
 
+impl<T> Sealed for UnitConstraint<T> where T: Float + Primitive {}
+
 impl<T> SupersetOf<NotNanConstraint<T>> for UnitConstraint<T> where T: Float + Primitive {}
 
 impl<T> SupersetOf<FiniteConstraint<T>> for UnitConstraint<T> where T: Float + Primitive {}
@@ -82,12 +86,13 @@ where
     fn filter_map(value: T) -> Option<T> {
         if value.is_nan() {
             None
-        }
-        else {
+        } else {
             Some(value)
         }
     }
 }
+
+impl<T> Sealed for NotNanConstraint<T> where T: Float + Primitive {}
 
 impl<T> SupersetOf<FiniteConstraint<T>> for NotNanConstraint<T> where T: Float + Primitive {}
 
@@ -109,9 +114,10 @@ where
     fn filter_map(value: T) -> Option<T> {
         if value.is_nan() || value.is_infinite() {
             None
-        }
-        else {
+        } else {
             Some(value)
         }
     }
 }
+
+impl<T> Sealed for FiniteConstraint<T> where T: Float + Primitive {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ mod proxy;
 use crate::cmp::IntrinsicOrd;
 use crate::constraint::{FiniteConstraint, NotNanConstraint, UnitConstraint};
 
+pub use crate::constraint::Constraint;
 pub use crate::proxy::Proxy;
 
 /// Floating-point representation with total ordering.
@@ -167,13 +168,11 @@ where
 
         if self.is_nan() {
             CANONICAL_NAN_BITS
-        }
-        else {
+        } else {
             let (mantissa, exponent, sign) = self.integer_decode();
             if mantissa == 0 {
                 CANONICAL_ZERO_BITS
-            }
-            else {
+            } else {
                 let exponent = u64::from(unsafe { mem::transmute::<i16, u16>(exponent) });
                 let sign = if sign > 0 { 1u64 } else { 0u64 };
                 (mantissa & MANTISSA_MASK)
@@ -252,8 +251,7 @@ impl Encoding for f32 {
         let exponent: i16 = ((bits >> 23) & 0xff) as i16;
         let mantissa = if exponent == 0 {
             (bits & 0x7f_ffff) << 1
-        }
-        else {
+        } else {
             (bits & 0x7f_ffff) | 0x80_0000
         };
         (mantissa as u64, exponent - (127 + 23), sign)
@@ -288,8 +286,7 @@ impl Encoding for f64 {
         let exponent: i16 = ((bits >> 52) & 0x7ff) as i16;
         let mantissa = if exponent == 0 {
             (bits & 0xf_ffff_ffff_ffff) << 1
-        }
-        else {
+        } else {
             (bits & 0xf_ffff_ffff_ffff) | 0x10_0000_0000_0000
         };
         (mantissa, exponent - (1023 + 52), sign)


### PR DESCRIPTION
Currently you cannot meaningfully implement any trait to `Proxy<T, P>` since you cannot name `P: Constraint<T>`. 