### PR TITLE
Allow `Proxy` to implement `Send`

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -136,7 +136,7 @@ where
 pub struct Proxy<T, P> {
     inner: T,
     #[cfg_attr(feature = "serialize-serde", serde(skip))]
-    phantom: PhantomData<*const P>,
+    phantom: PhantomData<fn() -> P>,
 }
 
 impl<T, P> Proxy<T, P> {


### PR DESCRIPTION
Proxy uses `PhantomData<*const P>`, which prevents it from implementing `Send`. I see that this was done intentionally for `Proxy` in https://github.com/olson-sean-k/decorum/commit/e86386237bb35964cfd5ebae092579f610a0ce4b (while all the other types use `fn() -> P`), but I don't understand why.

Is there a reason `Proxy` cannot safely implement `Send`, or some other reason `*const P` is required?