### PR TITLE
Initial `bytemuck::Pod` & `Zeroable` support on `Constrained`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,16 +35,27 @@ default = [
     "serde",
     "std",
 ]
+## Implements traits from [`approx`](https://crates.io/crates/approx) for `Constrained` types.
+approx = [
+    "dep:approx",
+]
+## Derives `Pod` & `Zeroable` traits from [`bytemuck`](https://crates.io/crates/bytemuck) for `Constrained` types.
+bytemuck = [
+    "dep:bytemuck",
+]
+## Enable support for [`serde`](https://crates.io/crates/serde) for `Constrained` types.
 serde = [
     "dep:serde",
     "dep:serde_derive",
 ]
+## Integrates the `std` library and enables dependent features.
 std = [
     "approx/std",
     "num-traits/std",
     "serde/std",
     "thiserror/std",
 ]
+## Enables features that require an unstable (`nighty`) compiler.
 unstable = []
 
 [dependencies.approx]
@@ -52,6 +63,14 @@ version = "^0.5.0"
 default-features = false
 features = []
 optional = true
+
+[dependencies.bytemuck]
+version = "^1.22"
+features = ["derive"]
+optional = true
+
+[dependencies.document-features]
+version = "0.2"
 
 [dependencies.num-traits]
 version = "^0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,9 @@
 //! [`Constraint`]: crate::constraint::Constraint
 //! [`Expression`]: crate::expression::Expression
 //! [`Try`]: core::ops::Try
-
+//!
+//! # Feature flags
+#![doc = document_features::document_features!()]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/olson-sean-k/decorum/master/doc/decorum-favicon.ico"
 )]

--- a/src/proxy/constrained.rs
+++ b/src/proxy/constrained.rs
@@ -85,6 +85,25 @@ pub struct Constrained<T, C> {
     phantom: PhantomData<fn() -> C>,
 }
 
+#[cfg(feature = "bytemuck")]
+unsafe impl<T, C> bytemuck::Pod for Constrained<T, C>
+where
+    Constrained<T, C>: Copy + Clone,
+    T: bytemuck::Zeroable + 'static,
+    C: 'static,
+{
+}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: bytemuck::Zeroable, C> bytemuck::Zeroable for Constrained<T, C> {
+    fn zeroed() -> Self {
+        Constrained {
+            inner: bytemuck::Zeroable::zeroed(),
+            phantom: PhantomData,
+        }
+    }
+}
+
 impl<T, C> Constrained<T, C> {
     pub(crate) const fn unchecked(inner: T) -> Self {
         Constrained {


### PR DESCRIPTION
See subject.

This is behind a `bytemuck` feature flag.

While at it, I also added feature flag docs (on crate docs) via the `document-features` crate.